### PR TITLE
Fix code scanning alert no. 5: Query built from user-controlled sources

### DIFF
--- a/src/main/java/com/example/rentalproperty/repository/RentalPropertyRepoImpl.java
+++ b/src/main/java/com/example/rentalproperty/repository/RentalPropertyRepoImpl.java
@@ -65,9 +65,8 @@ public class RentalPropertyRepoImpl implements IRentalPropertyRepository {
 
 	@Override
 	public List<RentalPropertyModel> findByType(String type) throws PropertyNotFoundException {
-		String query = "Select * from rentalProperty where type = "+type;
-//		Object[] property = {category};
-		return jdbcTemplate.query(query, BeanPropertyRowMapper.newInstance(RentalPropertyModel.class));
+		String query = "Select * from rentalProperty where type = ?";
+		return jdbcTemplate.query(query, new Object[]{type}, BeanPropertyRowMapper.newInstance(RentalPropertyModel.class));
 	}
 
 	@Override
@@ -84,9 +83,8 @@ public class RentalPropertyRepoImpl implements IRentalPropertyRepository {
 
 	@Override
 	public List<RentalPropertyModel> findByCity(String city) throws PropertyNotFoundException {
-		String query = "Select * from rentalProperty where city ="+city;
-//		Object[] property = {city};
-		return jdbcTemplate.query(query, BeanPropertyRowMapper.newInstance(RentalPropertyModel.class));
+		String query = "Select * from rentalProperty where city = ?";
+		return jdbcTemplate.query(query, new Object[]{city}, BeanPropertyRowMapper.newInstance(RentalPropertyModel.class));
 	}
 
 	@Override
@@ -105,8 +103,8 @@ public class RentalPropertyRepoImpl implements IRentalPropertyRepository {
 
 	@Override
 	public List<RentalPropertyModel> findByRentRange(String lowerRange, String higherRange) throws PropertyNotFoundException {
-		String query = "Select * from rentalProperty where rentalExpected between "+lowerRange +" and "+higherRange;
-		List<RentalPropertyModel> lst = jdbcTemplate.query(query, BeanPropertyRowMapper.newInstance(RentalPropertyModel.class));
+		String query = "Select * from rentalProperty where rentalExpected between ? and ?";
+		List<RentalPropertyModel> lst = jdbcTemplate.query(query, new Object[]{lowerRange, higherRange}, BeanPropertyRowMapper.newInstance(RentalPropertyModel.class));
 		return lst;
 	}
 


### PR DESCRIPTION
Fixes [https://github.com/omkumarkaushik/Property/security/code-scanning/5](https://github.com/omkumarkaushik/Property/security/code-scanning/5)

To fix the problem, we need to replace the string concatenation used to build SQL queries with prepared statements. This involves using placeholders (`?`) in the SQL query and setting the values using the `setString` method of `PreparedStatement`. This approach ensures that user-provided values are properly escaped and prevents SQL injection attacks.

1. Identify the lines where SQL queries are constructed using string concatenation with user-provided values.
2. Replace the concatenated query strings with parameterized queries using placeholders.
3. Use the `setString` method to set the values of the placeholders in the prepared statement.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
