### PR TITLE
Potential fix for code scanning alert no. 2: Query built from user-controlled sources

### DIFF
--- a/src/main/java/com/example/rentalproperty/repository/RentalPropertyRepoImpl.java
+++ b/src/main/java/com/example/rentalproperty/repository/RentalPropertyRepoImpl.java
@@ -57,9 +57,8 @@ public class RentalPropertyRepoImpl implements IRentalPropertyRepository {
 
 	@Override
 	public List<RentalPropertyModel> findByCategory(String category) throws PropertyNotFoundException {
-		String query = "Select * from rentalProperty where bedrooms = "+category;
-//		Object[] property = {category};
-		return jdbcTemplate.query(query, BeanPropertyRowMapper.newInstance(RentalPropertyModel.class));
+		String query = "Select * from rentalProperty where bedrooms = ?";
+		return jdbcTemplate.query(query, new Object[]{category}, BeanPropertyRowMapper.newInstance(RentalPropertyModel.class));
 		
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/omkumarkaushik/Property/security/code-scanning/2](https://github.com/omkumarkaushik/Property/security/code-scanning/2)

To fix this vulnerability, avoid string concatenation in query construction and use parameterized queries with the `JdbcTemplate`. Replace the line that constructs the query (currently: `String query = "Select * from rentalProperty where bedrooms = "+category;`) with a query string that uses a `?` placeholder for the parameter, and pass the parameter value in an argument array to `jdbcTemplate.query`. This requires altering both the query string and how `jdbcTemplate.query` is invoked. If the field `bedrooms` is an integer, consider parsing or validating `category` as an integer before passing it in; otherwise, treat it as a string parameter appropriately.

Edit only `src/main/java/com/example/rentalproperty/repository/RentalPropertyRepoImpl.java`, specifically the `findByCategory` method to use parameterization, and remove the insecure concatenation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
